### PR TITLE
fix: update npm package badges to use shields.io format

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 An MCP server for Claude Code that automates your Git workflow, from local commits to GitHub pull requests.
 
-[![npm version](https://badge.fury.io/js/@jdrhyne%2Fclaude-code-github.svg)](https://www.npmjs.com/package/@jdrhyne/claude-code-github)
-[![npm](https://img.shields.io/npm/dt/@jdrhyne/claude-code-github.svg)](https://www.npmjs.com/package/@jdrhyne/claude-code-github)
+[![npm version](https://img.shields.io/npm/v/@jdrhyne/claude-code-github.svg)](https://www.npmjs.com/package/@jdrhyne/claude-code-github)
+[![npm downloads](https://img.shields.io/npm/dt/@jdrhyne/claude-code-github.svg)](https://www.npmjs.com/package/@jdrhyne/claude-code-github)
 [![CI](https://github.com/jdrhyne/claude-code-github/actions/workflows/ci.yml/badge.svg)](https://github.com/jdrhyne/claude-code-github/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/jdrhyne/claude-code-github/actions/workflows/codeql.yml/badge.svg)](https://github.com/jdrhyne/claude-code-github/actions/workflows/codeql.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
## Summary
- Replace badge.fury.io with shields.io for npm version badge to fix display issues
- Use consistent badge format across all shields
- Fix URL encoding issues in badge URLs

## Changes
- Updated npm version badge from `badge.fury.io` to `shields.io/npm/v/`
- Added "downloads" label to npm downloads badge for clarity

## Test plan
- [x] Verify badges render correctly on GitHub
- [x] Confirm npm package link works properly
- [x] Ensure all other badges remain functional