### PR TITLE
fix: update npm downloads badge to use monthly stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 An MCP server for Claude Code that automates your Git workflow, from local commits to GitHub pull requests.
 
 [![npm version](https://img.shields.io/npm/v/@jdrhyne/claude-code-github.svg)](https://www.npmjs.com/package/@jdrhyne/claude-code-github)
-[![npm downloads](https://img.shields.io/npm/dt/@jdrhyne/claude-code-github.svg)](https://www.npmjs.com/package/@jdrhyne/claude-code-github)
+[![npm downloads](https://img.shields.io/npm/dm/@jdrhyne/claude-code-github.svg)](https://www.npmjs.com/package/@jdrhyne/claude-code-github)
 [![CI](https://github.com/jdrhyne/claude-code-github/actions/workflows/ci.yml/badge.svg)](https://github.com/jdrhyne/claude-code-github/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/jdrhyne/claude-code-github/actions/workflows/codeql.yml/badge.svg)](https://github.com/jdrhyne/claude-code-github/actions/workflows/codeql.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
## Summary
- Fixed npm downloads badge display issue
- Badge now shows monthly download statistics

## Problem
The downloads badge was showing "package not found or too new" error.

## Solution
Changed the badge URL from `/dt/` (total downloads) to `/dm/` (monthly downloads).

Monthly download badges work more reliably for newer npm packages and provide better visibility into current usage patterns.

## Result
- Downloads badge now displays correctly
- Shows monthly download count instead of all-time total
- More relevant metric for active package usage