### PR TITLE
fix: prevent duplicate GitHub Packages publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,11 +131,26 @@ jobs:
     - name: Build
       run: npm run build
 
-    - name: Check if version changed
+    - name: Check if version exists in GitHub Packages
       id: version
       run: |
         PACKAGE_VERSION=$(node -p "require('./package.json').version")
         echo "version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
+        
+        # Configure npm for GitHub Packages auth
+        echo "@jdrhyne:registry=https://npm.pkg.github.com" > .npmrc
+        echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
+        
+        # Check if version already exists in GitHub Packages
+        if npm view @jdrhyne/claude-code-github@$PACKAGE_VERSION version --registry=https://npm.pkg.github.com 2>/dev/null; then
+          echo "Version $PACKAGE_VERSION already exists in GitHub Packages"
+          echo "exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "Version $PACKAGE_VERSION does not exist in GitHub Packages"
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Configure npm for GitHub Packages
       run: |
@@ -145,7 +160,7 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Publish to GitHub Packages
-      if: steps.version.outputs.version != ''
+      if: steps.version.outputs.exists == 'false'
       run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Fixes CI failures caused by attempting to publish existing versions to GitHub Packages
- Adds proper version existence check before publishing

## Problem
The CI was failing with:
```
npm error 409 Conflict - Cannot publish over existing version
```

This happened because version 1.0.2 was already published to GitHub Packages, but the CI kept trying to publish it again on every push to main.

## Solution
1. Added version existence check using `npm view` before attempting to publish
2. Only publish to GitHub Packages when the version doesn't already exist
3. Properly configure npm auth for the version check

## Result
- CI will now skip GitHub Packages publishing if version already exists
- No more 409 Conflict errors
- CI runs are now idempotent - can be re-run without failures
- Both npm and GitHub Packages publishing work correctly

## Testing
The fix will be validated when this PR merges and the CI runs successfully without the publish-github-packages job failing.